### PR TITLE
Add print for raw header and avoid allocating headers

### DIFF
--- a/csvfind_v2.rs
+++ b/csvfind_v2.rs
@@ -21,13 +21,14 @@ fn main() -> std::io::Result<()> {
     let reader = BufReader::new(input_file);
     let mut lines = reader.lines();
 
-    let headers = lines
+    let raw_headers = lines
         .next()
-        .expect("Headers should be presented in the CSV file")?
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .collect::<Vec<_>>();
+        .expect("Headers should be presented in the CSV file")?;
 
+    println!("{}", raw_headers);
+
+    let headers = raw_headers.split(',').map(str::trim).collect::<Vec<_>>();
+    
     for line in lines {
         let line = line?;
 


### PR DESCRIPTION
Added a `println` for the raw headers line, and this also removes the heap allocation for each of the headers.

> Since the raw headers line is now captured, we can reduce the amount of heap allocation.