### PR TITLE
str_contains_i

### DIFF
--- a/csvfind_fork.php
+++ b/csvfind_fork.php
@@ -1,0 +1,37 @@
+<?php
+if( $argc < 3 ) {
+    printf( "Usage: %s INPUT_FILE SEARCH_TERM [HEADER_NAME]\n",$argv[0] );
+    exit;
+}
+
+$input_file  = $argv[1];
+$search_term = ( $argv[2] );
+$header_name = $argv[3] ?? null;
+$headers = [];
+$file = fopen( $input_file, "r" );
+$firstLine = fgets( $file );
+
+echo $firstLine;
+
+$headerIndex = null;
+
+if ($header_name) {
+    $headers = array_map(static fn (string $value) => trim($value), explode(",", $firstLine));
+    $headerIndex = array_search($header_name, $headers);
+}
+
+while (($line = fgets($file)) !== false) {
+    if( str_contains_i( $line, $search_term )  ) {
+
+        if ($headerIndex === null) {
+            echo $line;
+            continue;
+        }
+
+        $cols = explode(",", $line);
+        if (array_key_exists($headerIndex, $cols) && str_contains_i($cols[$headerIndex], $search_term) !== false) {
+            echo $line;
+        }
+    }
+}
+fclose($file);

--- a/test.php
+++ b/test.php
@@ -8,9 +8,11 @@ exec( "rustc -O -o rust-csvfindv2-test csvfind_v2.rs" );
 
 // run tests
 echo "Testing...\n";
-test( "php csvfind.php output.csv winkpad", 5 );
-test( "php csvfind_v2.php output.csv winkpad", 5 );
-test( "php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 csvfind_v2.php output.csv winkpad", 5 );
+test( "/usr/local/bin/php csvfind.php output.csv winkpad", 5 );
+test( "/usr/local/bin/php csvfind_v2.php output.csv winkpad", 5 );
+test( "/usr/local/bin/php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 csvfind_v2.php output.csv winkpad", 5 );
+test( "/usr/local/bin/php csvfind_fork.php output.csv winkpad", 5 );
+test( "/usr/local/bin/php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 csvfind_fork.php output.csv winkpad", 5 );
 test( "./c-csvfind-test-orig output.csv winkpad", 5 );
 test( "./c-csvfind-test output.csv winkpad", 5 );
 test( "./rust-csvfind-test output.csv winkpad", 5 );


### PR DESCRIPTION
Hello,

i'm back with another idea `str_contains` is faster than `strpos` but there is not insensitive equivalent, so i added it into https://github.com/fezfez/php-src/pull/1

my benchmark  : 

```
:~/work/oss/csvfind$ php test.php 
Compiling...
Testing...
4.713205s: /usr/local/bin/php csvfind.php output.csv winkpad
1.304393s: /usr/local/bin/php csvfind_v2.php output.csv winkpad
1.276952s: /usr/local/bin/php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 csvfind_v2.php output.csv winkpad
1.247178s: /usr/local/bin/php csvfind_fork.php output.csv winkpad
1.255567s: /usr/local/bin/php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 csvfind_fork.php output.csv winkpad
3.868123s: ./c-csvfind-test-orig output.csv winkpad
3.925151s: ./c-csvfind-test output.csv winkpad
8.339386s: ./rust-csvfind-test output.csv winkpad
3.590922s: ./rust-csvfindv2-test output.csv winkpad
:~/work/oss/csvfind$ wc -l output.csv 
880000 output.csv
```